### PR TITLE
Potential fix for code scanning alert no. 14: Server-side request forgery

### DIFF
--- a/apps/web/components/actions/scrapeMessages.ts
+++ b/apps/web/components/actions/scrapeMessages.ts
@@ -6,8 +6,16 @@ import { checkAdminPermissions } from "@/components/checkAdminPermissions";
 const url = process.env.POCKETBASE_URL;
 const guild_collection_name = "guilds";
 
+function isValidDiscordId(value: string): boolean {
+  return /^[0-9]+$/.test(value);
+}
+
 export async function scrapeMessagesAction(id: string) {
   await checkAdminPermissions();
+
+  if (!isValidDiscordId(id)) {
+    return { error: 400 };
+  }
 
   const pb = new PocketBase(url);
   try {
@@ -23,7 +31,9 @@ export async function scrapeMessagesAction(id: string) {
       .getFirstListItem(`discordID='${id}'`, {});
 
     if (guild.beingScraped === false) {
-      await fetch(`${process.env.API_URL}/serverScrape/${id}`);
+      const safeId = encodeURIComponent(id);
+      const scrapeUrl = new URL(`/serverScrape/${safeId}`, process.env.API_URL);
+      await fetch(scrapeUrl.toString());
       const data = {
         beingScraped: true,
       };


### PR DESCRIPTION
Potential fix for [https://github.com/cially/cially/security/code-scanning/14](https://github.com/cially/cially/security/code-scanning/14)

The best fix is to ensure user input cannot alter URL structure:

1. **Validate** `id` against a strict allowlist of expected characters (for example Discord/guild IDs are numeric snowflakes, so digits-only is appropriate).
2. **Encode** the path segment with `encodeURIComponent` before appending.
3. **Build URL with `URL`** to avoid string-concatenation URL mistakes.

In `apps/web/components/actions/scrapeMessages.ts`, add a small validator helper near the constants, then in `scrapeMessagesAction` reject invalid IDs before any downstream use, and replace the direct template-string `fetch` with URL object construction using the sanitized ID.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject invalid Discord IDs with a clear error response.
  * Improved request URL handling to ensure IDs are safely encoded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->